### PR TITLE
Enabled hardware zoom to support 7 Plus camera

### DIFF
--- a/VideoCore.podspec
+++ b/VideoCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name                = "VideoCore"
   s.module_name         = "VideoCore"
-  s.version             = "0.3.2"
+  s.version             = "0.4.0"
   s.summary             = "An audio and video manipulation and streaming pipeline with support for RTMP."
   s.description      = <<-DESC
                           This is a work-in-progress library with the

--- a/videocore/api/iOS/VCSimpleSession.mm
+++ b/videocore/api/iOS/VCSimpleSession.mm
@@ -289,13 +289,12 @@ namespace videocore { namespace simpleApi {
 {
     _videoZoomFactor = videoZoomFactor;
     if(m_positionTransform) {
-        // We could use AVCaptureConnection's zoom factor, but in reality it's
-        // doing the exact same thing as this (in terms of the algorithm used),
-        // but it is not clear how CoreVideo accomplishes it.
-        // In this case this is just modifying the matrix
-        // multiplication that is already happening once per frame.
-        m_positionTransform->setSize(self.videoSize.width * videoZoomFactor,
-                                     self.videoSize.height * videoZoomFactor);
+        // Switched to Hardware zoom to better support iPhone 7 Plus
+        m_cameraSource->setVideoZoomFactor(MAX(1.0, MIN(videoZoomFactor, 6.4)));
+        
+        // Original VideoCore code:
+        //m_positionTransform->setSize(self.videoSize.width * videoZoomFactor,
+        //                             self.videoSize.height * videoZoomFactor);
     }
 }
 - (void) setAudioChannelCount:(int)channelCount

--- a/videocore/sources/iOS/CameraSource.h
+++ b/videocore/sources/iOS/CameraSource.h
@@ -114,6 +114,7 @@ namespace videocore { namespace iOS {
         
         bool setContinuousExposure(bool wantsContinuous);
         
+        bool setVideoZoomFactor(float zoomFactor);
         
     public:
         /*! Used by Objective-C Capture Session */

--- a/videocore/sources/iOS/CameraSource.mm
+++ b/videocore/sources/iOS/CameraSource.mm
@@ -503,5 +503,17 @@ namespace videocore { namespace iOS {
         return ret;
     }
     
+    bool
+    CameraSource::setVideoZoomFactor(float zoomFactor) {
+        AVCaptureDevice* device = (AVCaptureDevice*)m_captureDevice;
+        NSError* err = nil;
+        if([device lockForConfiguration:&err]) {
+            device.videoZoomFactor = zoomFactor;
+            return YES;
+        } else {
+            return NO;
+        }
+    }
+    
 }
 }


### PR DESCRIPTION
The software zoom would have bypassed the iPhone 7+ 56mm camera advantages. 
